### PR TITLE
added column_count output to GET /api/article/:article_id endpoint. 

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -59,7 +59,8 @@ describe('/api/articles/:article_id endpoint', () => {
       .get('/api/articles/1')
       .expect(200)
       .then(({ body }) => {
-        expect(body.article).toEqual(expectedArticle)
+        const {comment_count,...article} = body.article
+        expect(article).toEqual(expectedArticle)
       })
   })
   test('GET: 400 when requesting an article with an invalid id', () => {
@@ -77,6 +78,14 @@ describe('/api/articles/:article_id endpoint', () => {
       .then(({ body }) => {
         expect(body.msg).toEqual('requested ID not found')
       })
+  })
+  test("GET: 200 should include a comment_count of all the comments on the specified article_id", () => {
+    return request(app)
+    .get('/api/articles/1')
+    .expect(200)
+    .then(({body}) => {
+      expect(body.article.comment_count).toBe(11)
+    })
   })
   test('PATCH: 200 should increment the votes of a specified article by the supplied amount', () => {
     const expectedArticle = {

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -17,12 +17,17 @@ exports.selectArticles = (topic) => {
 }
 
 exports.selectArticleyById = (id) => {
+  const baseString = `
+  SELECT articles.*, CAST(COUNT(comment_id) AS INT) comment_count 
+  FROM articles
+  LEFT OUTER JOIN comments 
+  ON articles.article_id = comments.article_id
+  GROUP BY articles.article_id`
+  const queryString = `SELECT * FROM (` + baseString + `) a 
+  WHERE article_id = $1`
+  const queryVals = [id]
   return db
-    .query(
-      `SELECT * FROM articles
-  WHERE article_id = $1`,
-      [id]
-    )
+    .query(queryString,queryVals)
     .then(({ rows }) => {
       if (!rows.length) {
         return Promise.reject({


### PR DESCRIPTION
I realise it is poor practice to modify previous tests but in this case I couldn't think of how to pass the first test on this endpoint without modifying to cope with added functionality.